### PR TITLE
fix `$ref` bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These scripts use [`turbo`](https://turbo.build/) to build all the dependencies 
 | `pnpm dev:client:app`     | Runs the API Client desktop app in a browser dev environment (with HMR\*) |
 | `pnpm dev:client:modal`   | Runs the API Client modal layout (with HMR\*)                             |
 | `pnpm dev:client:web`     | Runs the API Client client web app (with HMR\*)                           |
-| `pnpm dev:components`     | Runs storybook for `@mintlify/components`                                   |
+| `pnpm dev:components`     | Runs storybook for `@mintlify/components`                                 |
 | `pnpm dev:nuxt`           | Runs the [Nuxt](https://nuxt.com/) package                                |
 | `pnpm dev:proxy-server`   | Runs the Scalar proxy server locally                                      |
 | `pnpm dev:reference`      | Runs the API References dev environment (with HMR\*)                      |


### PR DESCRIPTION
**Problem**
Currently, any properties named `$ref` get treated as references, and cause errors because their value is usually `{ type: 'string' }`. This could potentially be a problem with any dynamic-key field (such as `headers` or `scopes`, but technically not `components.schemas` since `$` is not an allowed character)

**Solution**
This PR adds a workaround which keeps track of whether the recursive function is inside a `properties` field
